### PR TITLE
Fix bucket creation date in folder backend

### DIFF
--- a/internal/backends/storage/folder/backend.go
+++ b/internal/backends/storage/folder/backend.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/zhulik/d3/internal/core"
 	"github.com/zhulik/d3/pkg/xiter"
@@ -18,6 +20,10 @@ const (
 
 type configYaml struct {
 	Version int `yaml:"version"`
+}
+
+type bucketMetadata struct {
+	CreationDate time.Time `yaml:"creationDate"`
 }
 
 type Backend struct {
@@ -77,12 +83,26 @@ func (b *Backend) CreateBucket(_ context.Context, name string) error {
 		return err
 	}
 
+	err = yaml.MarshalToFile(bucketMetadata{CreationDate: time.Now()}, b.bucketMetadataPath(name))
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
 func (b *Backend) DeleteBucket(_ context.Context, name string) error {
 	path, err := b.config.bucketPath(name)
 	if err != nil {
+		return err
+	}
+
+	metadataPath := b.bucketMetadataPath(name)
+	if err := rejectSymlink(metadataPath); err != nil {
+		return err
+	}
+
+	if err := os.Remove(metadataPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 
@@ -124,9 +144,14 @@ func (b *Backend) HeadBucket(_ context.Context, name string) (core.Bucket, error
 		return nil, err
 	}
 
+	creationDate, err := b.bucketCreationDate(name, info)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Bucket{
 		name:         name,
-		creationDate: info.ModTime(), // TODO: use the actual creation date
+		creationDate: creationDate,
 		config:       b.config,
 		Locker:       b.Locker,
 	}, nil
@@ -142,12 +167,41 @@ func (b *Backend) dirEntryToBucket(entry os.DirEntry) (core.Bucket, bool, error)
 		return nil, false, err
 	}
 
+	creationDate, err := b.bucketCreationDate(entry.Name(), info)
+	if err != nil {
+		return nil, false, err
+	}
+
 	return &Bucket{
 		name:         entry.Name(),
-		creationDate: info.ModTime(), // TODO: use the actual creation date
+		creationDate: creationDate,
 		config:       b.config,
 		Locker:       b.Locker,
 	}, true, nil
+}
+
+func (b *Backend) bucketMetadataPath(name string) string {
+	return filepath.Join(b.config.bucketsPath(), name, "bucket.yaml")
+}
+
+func (b *Backend) bucketCreationDate(name string, info os.FileInfo) (time.Time, error) {
+	path := b.bucketMetadataPath(name)
+
+	if err := rejectSymlink(path); err != nil {
+		return time.Time{}, err
+	}
+
+	metadata, err := yaml.UnmarshalFromFile[bucketMetadata](path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// Buckets created before bucket metadata support use mtime as a best-effort fallback.
+			return info.ModTime(), nil
+		}
+
+		return time.Time{}, err
+	}
+
+	return metadata.CreationDate, nil
 }
 
 func (b *Backend) prepareFileStructure(ctx context.Context) error {

--- a/internal/backends/storage/folder/backend_bucket_creation_test.go
+++ b/internal/backends/storage/folder/backend_bucket_creation_test.go
@@ -1,0 +1,85 @@
+package folder //nolint:testpackage
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	"github.com/zhulik/d3/internal/core"
+)
+
+var _ = Describe("Backend bucket creation date", func() {
+	var (
+		tmpDir  string
+		backend *Backend
+	)
+
+	BeforeEach(func(ctx SpecContext) {
+		tmpDir = lo.Must(os.MkdirTemp("", "bucket-creation-date-*"))
+
+		DeferCleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+		backend = &Backend{
+			Cfg: &core.Config{
+				FolderStorageBackendPath: tmpDir,
+			},
+			Locker: noopLocker{},
+		}
+
+		lo.Must0(backend.Init(ctx))
+	})
+
+	When("a bucket exists with metadata", func() {
+		It("keeps creation date stable when directory mtime changes", func(ctx SpecContext) {
+			lo.Must0(backend.CreateBucket(ctx, "stable"))
+
+			initialBucket := lo.Must(backend.HeadBucket(ctx, "stable"))
+			initialCreationDate := initialBucket.CreationDate()
+
+			bucketPath := lo.Must(backend.config.bucketPath("stable"))
+			touched := initialCreationDate.Add(2 * time.Hour)
+			lo.Must0(os.Chtimes(bucketPath, touched, touched))
+
+			// Ensure test setup actually changed the directory mtime.
+			stat := lo.Must(os.Lstat(bucketPath))
+			Expect(stat.ModTime()).NotTo(Equal(initialCreationDate))
+
+			afterHead := lo.Must(backend.HeadBucket(ctx, "stable"))
+			Expect(afterHead.CreationDate()).To(Equal(initialCreationDate))
+
+			listed := lo.Must(backend.ListBuckets(ctx))
+			Expect(listed).To(HaveLen(1))
+			Expect(listed[0].Name()).To(Equal("stable"))
+			Expect(listed[0].CreationDate()).To(Equal(initialCreationDate))
+		})
+	})
+
+	When("a bucket metadata file is missing", func() {
+		It("falls back to directory mtime", func(ctx SpecContext) {
+			lo.Must0(backend.CreateBucket(ctx, "legacy"))
+
+			metadataPath := filepath.Join(tmpDir, bucketsFolder, "legacy", "bucket.yaml")
+			lo.Must0(os.Remove(metadataPath))
+
+			bucketPath := lo.Must(backend.config.bucketPath("legacy"))
+			expected := time.Now().Add(3 * time.Hour).Truncate(time.Second)
+			lo.Must0(os.Chtimes(bucketPath, expected, expected))
+
+			got := lo.Must(backend.HeadBucket(ctx, "legacy"))
+			Expect(got.CreationDate().Unix()).To(Equal(expected.Unix()))
+		})
+	})
+
+	When("deleting an empty bucket with metadata", func() {
+		It("removes bucket successfully", func(ctx SpecContext) {
+			lo.Must0(backend.CreateBucket(ctx, "to-delete"))
+			lo.Must0(backend.DeleteBucket(ctx, "to-delete"))
+
+			_, err := backend.HeadBucket(ctx, "to-delete")
+			Expect(err).To(Equal(core.ErrBucketNotFound))
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- Persist bucket creation date in `bucket.yaml` when creating a bucket, and use it in `HeadBucket`/`ListBuckets` instead of directory mtime.
- Keep compatibility for pre-existing buckets by falling back to directory mtime when metadata is missing.
- Fix empty bucket deletion by removing metadata file before deleting the bucket directory, and add regression tests.
- Fixes #11.

## Type of change
- [x] Bug fix (fix-)
- [ ] New feature (feature-)
- [ ] Documentation only (doc-)
- [ ] Shore (shore-)
- [ ] CI (ci-)
- [ ] Dependency update(update-)

## Breaking changes
None.

## Testing
- [x] `task` (or equivalent: lint + unit tests) passes locally
- [x] Added or updated tests (if behavior changed or new code paths need coverage)
- [ ] Manual checks performed (describe briefly if relevant)

## Compatibility / docs
- [x] No compatibility or documentation impact, or docs/values updated as needed