### PR TITLE
Fix HeadObject authorization order for issue #19

### DIFF
--- a/internal/apis/s3/api_objects.go
+++ b/internal/apis/s3/api_objects.go
@@ -53,7 +53,7 @@ func (a APIObjects) Init(_ context.Context) error {
 	a.Echo.SetRootFallbackHandler(a.ListObjectsV2, s3actions.ListObjectsV2, bucketFinder, authorizer)
 
 	objects := a.Echo.Group("/:bucket/*", middlewares.ObjectKeyValidator)
-	objects.HEAD("", a.HeadObject, middlewares.SetAction(s3actions.HeadObject), bucketFinder, objectFinder, authorizer)
+	objects.HEAD("", a.HeadObject, middlewares.SetAction(s3actions.HeadObject), bucketFinder, authorizer, objectFinder)
 	objects.PUT("", NewQueryParamsRouter().
 		SetFallbackHandler(a.PutObject, s3actions.PutObject, bucketFinder, authorizer).
 		AddRoute("tagging", a.PutObjectTagging, s3actions.PutObjectTagging, bucketFinder, objectFinder, authorizer).

--- a/internal/apis/s3/api_objects_test.go
+++ b/internal/apis/s3/api_objects_test.go
@@ -1,15 +1,18 @@
 package s3_test
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/zhulik/d3/internal/apictx"
 	"github.com/zhulik/d3/internal/apis/s3"
 	"github.com/zhulik/d3/internal/apis/s3/middlewares"
 	"github.com/zhulik/d3/internal/core"
+	"github.com/zhulik/d3/pkg/s3actions"
 
 	"github.com/labstack/echo/v5"
 	. "github.com/onsi/ginkgo/v2"
@@ -107,6 +110,45 @@ var _ = Describe("S3ErrorRenderer", func() {
 			ok := errors.As(err, &httpErr)
 			Expect(ok).To(BeTrue())
 			Expect(httpErr.Code).To(Equal(http.StatusForbidden))
+		})
+	})
+})
+
+type capturingAuthorizer struct {
+	resource string
+}
+
+func (a *capturingAuthorizer) IsAllowed(
+	_ context.Context, _ *core.User, _ s3actions.Action, resource string,
+) (bool, error) {
+	a.resource = resource
+	return true, nil
+}
+
+var _ = Describe("S3AuthorizerMiddleware", func() {
+	When("head object request has no preloaded object", func() {
+		It("authorizes against bucket and key from URL", func() {
+			captured := &capturingAuthorizer{}
+			mw := (&middlewares.Authorizer{Authorizer: captured}).Middleware()
+
+			req := httptest.NewRequest(http.MethodHead, "/my-bucket/path/to/file.txt", nil)
+			rec := httptest.NewRecorder()
+			c := echo.New().NewContext(req, rec)
+			c.SetPath("/:bucket/*")
+			c.SetPathValues(echo.PathValues{
+				{Name: "bucket", Value: "my-bucket"},
+				{Name: "*", Value: "path/to/file.txt"},
+			})
+
+			ctx := apictx.Inject(c)
+			apiCtx := apictx.FromContext(ctx)
+			apiCtx.Action = s3actions.HeadObject
+			apiCtx.User = &core.User{Name: "reader"}
+			c.SetRequest(c.Request().WithContext(ctx))
+
+			err := mw(func(_ *echo.Context) error { return nil })(c)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(captured.resource).To(Equal("my-bucket/path/to/file.txt"))
 		})
 	})
 })

--- a/internal/apis/s3/middlewares/authorizer.go
+++ b/internal/apis/s3/middlewares/authorizer.go
@@ -49,9 +49,9 @@ func (a *Authorizer) Middleware() echo.MiddlewareFunc {
 				switch {
 				case apiCtx.Object != nil:
 					resource = bucketName + "/" + apiCtx.Object.Key()
-				case apiCtx.Action == s3actions.DeleteObject:
-					// DeleteObject does not use objectFinder (object may not exist; S3 returns 204 for non-existent keys).
-					// Authorize against the key from the URL to enforce prefix-based policies.
+				case apiCtx.Action == s3actions.DeleteObject || apiCtx.Action == s3actions.HeadObject:
+					// These operations can be authorized by URL key without preloading object metadata.
+					// This keeps authorization ahead of object lookup for HEAD and supports prefix policies.
 					if key := c.Param("*"); key != "" {
 						resource = bucketName + "/" + key
 					} else {


### PR DESCRIPTION
## Summary

Fixes #19.

- Run S3 `HeadObject` authorization before object lookup to avoid lookup-dependent behavior before access control.
- Allow authorizer to resolve `HeadObject` resource from URL key (`bucket/key`) when object metadata is not preloaded.
- Add regression test covering `HeadObject` middleware resource resolution.

## Type of change

- [x] Bug fix (fix-)
- [ ] New feature (feature-)
- [ ] Documentation only (doc-)
- [ ] Shore (shore-)
- [ ] CI (ci-)
- [ ] Dependency update(update-)

## Breaking changes

None.

## Testing

- [x] `task` (or equivalent: lint + unit tests) passes locally
- [x] Added or updated tests (if behavior changed or new code paths need coverage)
- [ ] Manual checks performed (describe briefly if relevant)

## Compatibility / docs

- [x] No compatibility or documentation impact, or docs/values updated as needed
