### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+d3 is a lightweight S3-compatible object storage server written in Go. It uses Redis for distributed locking and stores data on the local filesystem.
+
+### Prerequisites (installed via snapshot/setup)
+
+- **Go 1.25.6** (system Go)
+- **Redis** on `localhost:6379` — must be running before starting the server or running integration tests
+- **Task** (taskfile.dev) v3.49.1 — task runner
+- **golangci-lint** v2.11.4 — linter
+- **Ginkgo** v2.28.1 — test runner (installed to `~/go/bin/`, ensure `PATH` includes it)
+
+### Starting Redis
+
+Redis must be running before the d3 server or integration tests. Start it with:
+
+```bash
+redis-server --daemonize yes
+```
+
+Verify with `redis-cli ping` (should return `PONG`).
+
+### Development commands
+
+All standard commands are in `Taskfile.yml` and `tasks/*.yml`:
+
+| Command | Purpose |
+|---------|---------|
+| `task build` | Build all packages |
+| `task run` | Run server with hot reload (air) |
+| `task lint:lint` | Lint (no auto-fix) |
+| `task lint` | Lint with `--fix` |
+| `task test` | Unit tests (Ginkgo, excludes conformance) |
+| `task test:integration` | Integration tests (conformance + management) |
+| `task test:conformance` | S3 conformance tests only |
+| `task test:management` | Management API tests only |
+
+### Running the server manually
+
+```bash
+ENVIRONMENT=development ADMIN_CREDENTIALS_PATH=admin-credentials.dev.yaml go run ./cmd/d3-server
+```
+
+This starts the S3 API on `:8080`, health check on `:8081`, and management API on `:8082`. In `development` mode with `admin-credentials.dev.yaml`, the admin credentials are:
+- Access Key: `AKIAIOSFODNN7EXAMPLE`
+- Secret Key: `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`
+
+### Gotchas
+
+- **Ginkgo binary path**: `ginkgo` is installed to `~/go/bin/`. The `PATH` must include this directory. This is set in `~/.bashrc`.
+- **Integration tests require Redis**: They connect to `localhost:6379` (hardcoded in `integration/testhelpers/app.go`). Tests will fail immediately without Redis running.
+- **Lint has pre-existing issues**: `task lint:lint` (without `--fix`) reports 2 pre-existing `nlreturn`/`wsl_v5` issues in `internal/apis/s3/api_objects_test.go`. These are not caused by new changes.
+- **S3 API requires SigV4 signing**: Plain `curl` calls to port 8080 will get `403 Forbidden`. Use an S3 SDK client (Go AWS SDK, MinIO client, etc.) with the admin credentials above.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific development instructions for future cloud agents, including:
- Prerequisites and tool versions
- How to start Redis (required dependency)
- Development commands reference (pointing to `Taskfile.yml`)
- Server startup instructions with dev credentials
- Known gotchas (Ginkgo PATH, SigV4 signing, pre-existing lint issues)

## Type of change

- [ ] Bug fix (fix-)
- [ ] New feature (feature-)
- [x] Documentation only (doc-)
- [ ] Shore (shore-)
- [ ] CI (ci-)
- [ ] Dependency update(update-)

## Breaking changes

None

## Testing

- [x] `task` (or equivalent: lint + unit tests) passes locally
- [ ] Added or updated tests (if behavior changed or new code paths need coverage)
- [x] Manual checks performed (describe briefly if relevant)

All development tooling verified:
- `task build` — builds successfully
- `task lint:lint` — runs (2 pre-existing issues, not from this PR)
- `task test` — 12 unit test suites, all pass (317 specs)
- `task test:integration` — 204 integration tests pass (160 conformance + 44 management)
- S3 API manually tested with Go AWS SDK (create bucket, put/get/list/delete objects)

S3 demo output:
[s3_demo_output.log](https://cursor.com/agents/bc-9415842d-40b2-404c-b608-744fdcb9ca75/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fs3_demo_output.log)

## Compatibility / docs

- [x] No compatibility or documentation impact, or docs/values updated as needed

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9415842d-40b2-404c-b608-744fdcb9ca75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9415842d-40b2-404c-b608-744fdcb9ca75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

